### PR TITLE
handle more neptune additional failure states

### DIFF
--- a/databuilder/clients/neptune_client.py
+++ b/databuilder/clients/neptune_client.py
@@ -70,7 +70,7 @@ class BulkUploaderNeptuneClient:
             print(repr(status_response))
             raise Exception("Ran into error bulk loading")
 
-        if status not in ("LOAD_COMPLETED", "LOAD_IN_PROGRESS"):
+        if status not in ("LOAD_COMPLETED", "LOAD_IN_PROGRESS", "LOAD_NOT_STARTED", "LOAD_IN_QUEUE"):
             print(repr(status_response))
             raise Exception("Ran into error bulk loading")
 

--- a/databuilder/clients/neptune_client.py
+++ b/databuilder/clients/neptune_client.py
@@ -70,7 +70,7 @@ class BulkUploaderNeptuneClient:
             print(repr(status_response))
             raise Exception("Ran into error bulk loading")
 
-        if status == "LOAD_FAILED":
+        if status not in ("LOAD_COMPLETED", "LOAD_IN_PROGRESS"):
             print(repr(status_response))
             raise Exception("Ran into error bulk loading")
 


### PR DESCRIPTION
Catches another error state I ran into, something like "LOAD_CANCELLED_DUE_TO_ERRORS"

The list of valid states is here: https://docs.aws.amazon.com/neptune/latest/userguide/loader-message.html